### PR TITLE
CTC no more in contrib

### DIFF
--- a/bdlstm_train.py
+++ b/bdlstm_train.py
@@ -14,7 +14,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from tensorflow.contrib.ctc import ctc_ops as ctc
+from tensorflow.python.ops import ctc_ops as ctc
 from tensorflow.python.ops import rnn_cell
 from tensorflow.python.ops.rnn import bidirectional_rnn
 import numpy as np

--- a/bdlstm_train_sample.py
+++ b/bdlstm_train_sample.py
@@ -12,7 +12,7 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
-from tensorflow.contrib.ctc import ctc_ops as ctc
+from tensorflow.python.ops import ctc_ops as ctc
 from tensorflow.python.ops import rnn_cell
 from tensorflow.python.ops.rnn import bidirectional_rnn
 import numpy as np


### PR DESCRIPTION
Hello,

It seems that ctc_ops are now official in the current TF master branch (0.9.0) so I recommend to change _tensorflow.contrib.ctc_ to _tensorflow.python.ops_.

I have installed TF via nvidia-docker using this Dockerfile:
https://github.com/bver/tensorflow_CTC_example/blob/sample_dockerfile/Dockerfile

It works perfectly, bdlstm_train_sample.py ends with
Epoch 300 error rate: 0.0118518114323
after approx. six minutes on my GTX 970 box.

Thanks for your example!
Pavel
